### PR TITLE
Simplify StructuredElement Marshalling

### DIFF
--- a/src/main/java/fr/vidal/oss/jaxb/atom/core/ElementQNameFactory.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/core/ElementQNameFactory.java
@@ -1,7 +1,0 @@
-package fr.vidal.oss.jaxb.atom.core;
-
-import javax.xml.namespace.QName;
-
-public interface ElementQNameFactory {
-    QName qualifiedName(ExtensionElement simpleElement);
-}

--- a/src/main/java/fr/vidal/oss/jaxb/atom/core/ExtensionElement.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/core/ExtensionElement.java
@@ -1,5 +1,7 @@
 package fr.vidal.oss.jaxb.atom.core;
 
+import fr.vidal.oss.jaxb.atom.extensions.ExtensionElementConverter;
+
 import java.util.Collection;
 
 public interface ExtensionElement {
@@ -8,4 +10,6 @@ public interface ExtensionElement {
     String tagName();
 
     Collection<Attribute> attributes();
+
+    ExtensionElementConverter converter();
 }

--- a/src/main/java/fr/vidal/oss/jaxb/atom/extensions/AnyElement.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/extensions/AnyElement.java
@@ -20,7 +20,7 @@ public class AnyElement implements ExtensionElement {
     private Collection<ExtensionElement> anyElements;
 
     @SuppressWarnings("used by jaxb")
-    public AnyElement() {
+    private AnyElement() {
     }
 
     private AnyElement(Builder builder) {
@@ -36,6 +36,11 @@ public class AnyElement implements ExtensionElement {
 
     public String tagName() {
         return tagName;
+    }
+
+    @Override
+    public ExtensionElementConverter converter() {
+        return new AnyElementExtensionConverter();
     }
 
     public Collection<Attribute> attributes() {

--- a/src/main/java/fr/vidal/oss/jaxb/atom/extensions/AnyElementExtensionConverter.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/extensions/AnyElementExtensionConverter.java
@@ -1,28 +1,17 @@
 package fr.vidal.oss.jaxb.atom.extensions;
 
-import fr.vidal.oss.jaxb.atom.core.ElementQNameFactory;
 import fr.vidal.oss.jaxb.atom.core.ExtensionElement;
 
 import javax.xml.bind.JAXBElement;
 
-public class AnyElementExtensionConverter implements ExtensionElementConverter {
-    private ElementQNameFactory elementQNameFactory;
-
-    public AnyElementExtensionConverter(ElementQNameFactory elementQNameFactory) {
-        this.elementQNameFactory = elementQNameFactory;
-    }
+class AnyElementExtensionConverter extends ExtensionElementConverter {
 
     @Override
     public JAXBElement<AnyElement> convert(ExtensionElement element) {
         return new JAXBElement<>(
-            elementQNameFactory.qualifiedName(element),
+            qualifiedName(element),
             AnyElement.class,
             (AnyElement) element
         );
-    }
-
-    @Override
-    public boolean canConvert(ExtensionElement extensionElement) {
-        return extensionElement instanceof AnyElement;
     }
 }

--- a/src/main/java/fr/vidal/oss/jaxb/atom/extensions/ExtensionElementConverter.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/extensions/ExtensionElementConverter.java
@@ -1,12 +1,20 @@
 package fr.vidal.oss.jaxb.atom.extensions;
 
 import fr.vidal.oss.jaxb.atom.core.ExtensionElement;
+import fr.vidal.oss.jaxb.atom.core.Namespace;
 
 import javax.xml.bind.JAXBElement;
+import javax.xml.namespace.QName;
 
-public interface ExtensionElementConverter {
+public abstract class ExtensionElementConverter {
 
-    boolean canConvert(ExtensionElement extensionElement);
+    public abstract <T> JAXBElement<T> convert(ExtensionElement element);
 
-    <T> JAXBElement<T> convert(ExtensionElement element);
+    protected QName qualifiedName(ExtensionElement simpleElement) {
+        Namespace namespace = simpleElement.namespace();
+        if (namespace != null) {
+            return new QName(namespace.uri(), simpleElement.tagName(), namespace.prefix());
+        }
+        return new QName(simpleElement.tagName());
+    }
 }

--- a/src/main/java/fr/vidal/oss/jaxb/atom/extensions/SimpleElement.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/extensions/SimpleElement.java
@@ -49,6 +49,11 @@ public class SimpleElement implements ExtensionElement {
         return value;
     }
 
+    @Override
+    public ExtensionElementConverter converter() {
+        return new SimpleElementExtensionConverter();
+    }
+
     public Collection<Attribute> attributes() {
         return unmodifiableCollection(attributes);
     }

--- a/src/main/java/fr/vidal/oss/jaxb/atom/extensions/SimpleElementExtensionConverter.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/extensions/SimpleElementExtensionConverter.java
@@ -1,29 +1,19 @@
 package fr.vidal.oss.jaxb.atom.extensions;
 
-import fr.vidal.oss.jaxb.atom.core.ElementQNameFactory;
 import fr.vidal.oss.jaxb.atom.core.ExtensionElement;
 
 import javax.xml.bind.JAXBElement;
 
-public class SimpleElementExtensionConverter implements ExtensionElementConverter {
-    private ElementQNameFactory elementQNameFactory;
-
-    public SimpleElementExtensionConverter(ElementQNameFactory elementQNameFactory) {
-        this.elementQNameFactory = elementQNameFactory;
-    }
+class SimpleElementExtensionConverter extends ExtensionElementConverter {
 
     @Override
     public JAXBElement<String> convert(ExtensionElement element) {
         SimpleElement simpleElement = (SimpleElement) element;
         return new JAXBElement<>(
-            elementQNameFactory.qualifiedName(element),
+            qualifiedName(element),
             String.class,
             simpleElement.value()
         );
     }
 
-    @Override
-    public boolean canConvert(ExtensionElement extensionElement) {
-        return extensionElement instanceof SimpleElement;
-    }
 }

--- a/src/main/java/fr/vidal/oss/jaxb/atom/extensions/StructuredElement.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/extensions/StructuredElement.java
@@ -30,7 +30,7 @@ public class StructuredElement implements ExtensionElement {
     private Collection<ExtensionElement> extensionElements;
 
     @SuppressWarnings("unused") //jaxb
-    public StructuredElement() {
+    private StructuredElement() {
     }
 
     private StructuredElement(Builder builder) {
@@ -53,6 +53,11 @@ public class StructuredElement implements ExtensionElement {
     @Override
     public Collection<Attribute> attributes() {
         return unmodifiableCollection(attributes);
+    }
+
+    @Override
+    public ExtensionElementConverter converter() {
+        return new StructuredElementExtensionConverter();
     }
 
     public Collection<ExtensionElement> getExtensionElements() {

--- a/src/main/java/fr/vidal/oss/jaxb/atom/extensions/StructuredElementExtensionConverter.java
+++ b/src/main/java/fr/vidal/oss/jaxb/atom/extensions/StructuredElementExtensionConverter.java
@@ -1,28 +1,18 @@
 package fr.vidal.oss.jaxb.atom.extensions;
 
-import fr.vidal.oss.jaxb.atom.core.ElementQNameFactory;
 import fr.vidal.oss.jaxb.atom.core.ExtensionElement;
 
 import javax.xml.bind.JAXBElement;
 
-public class StructuredElementExtensionConverter implements ExtensionElementConverter {
-    private ElementQNameFactory elementQNameFactory;
-
-    public StructuredElementExtensionConverter(ElementQNameFactory elementQNameFactory) {
-        this.elementQNameFactory = elementQNameFactory;
-    }
+class StructuredElementExtensionConverter extends ExtensionElementConverter {
 
     @Override
     public JAXBElement<StructuredElement> convert(ExtensionElement element) {
         return new JAXBElement<>(
-            elementQNameFactory.qualifiedName(element),
+            qualifiedName(element),
             StructuredElement.class,
             (StructuredElement) element
         );
     }
 
-    @Override
-    public boolean canConvert(ExtensionElement extensionElement) {
-        return extensionElement instanceof StructuredElement;
-    }
 }

--- a/src/test/java/fr/vidal/oss/jaxb/atom/MarshallingTest.java
+++ b/src/test/java/fr/vidal/oss/jaxb/atom/MarshallingTest.java
@@ -11,6 +11,7 @@ import fr.vidal.oss.jaxb.atom.core.Link;
 import fr.vidal.oss.jaxb.atom.core.Namespace;
 import fr.vidal.oss.jaxb.atom.core.Summary;
 import fr.vidal.oss.jaxb.atom.extensions.AnyElement;
+import fr.vidal.oss.jaxb.atom.extensions.ExtensionElementConverter;
 import fr.vidal.oss.jaxb.atom.extensions.SimpleElement;
 import fr.vidal.oss.jaxb.atom.extensions.StructuredElement;
 
@@ -549,54 +550,6 @@ public class MarshallingTest {
                     "    </vidal:dosages>\n" +
                     "</feed>\n");
         }
-    }
-
-    @Test
-    public void should_raise_an_exception_when_marshalling_an_unknown_element() throws IOException, JAXBException {
-        final Feed.Builder builder = Feed.builder()
-            .withId("Heidi")
-            .withTitle("Search Products - Query :sintrom")
-            .addLink(Link.builder("/rest/api/products?q=sintrom&amp;start-page=1&amp;page-size=25").withRel(self).withType("application/atom+xml").build())
-            .withUpdateDate(new Date(1329350400000L))
-
-            .addExtensionElement(unknownAdditionalElement()
-            );
-
-        try (StringWriter writer = new StringWriter()) {
-            try {
-                marshaller.marshal(builder.build(), writer);
-                fail("Missing attribute");
-            } catch (MarshalException e) {
-                Throwable exception = e.getLinkedException();
-
-                assertThat(exception).hasCauseInstanceOf(IllegalArgumentException.class)
-                    .hasMessage("Cannot handle Additional element: " + "An unknown Additional Element");
-            }
-        }
-    }
-
-    private ExtensionElement unknownAdditionalElement() {
-        return new ExtensionElement() {
-            @Override
-            public Namespace namespace() {
-                return null;
-            }
-
-            @Override
-            public String tagName() {
-                return null;
-            }
-
-            @Override
-            public Collection<Attribute> attributes() {
-                return null;
-            }
-
-            @Override
-            public String toString() {
-                return "An unknown Additional Element";
-            }
-        };
     }
 
     @Test


### PR DESCRIPTION
Par rapport a la PR qui ajoute la gestion des éléments structurés dans la lib, je propose une version qui selon moi est plus simple et plus propre :

- Donner au StructuredElement la connaissance de son Converter dédié, au travers de la methode `converter()`. Cela a du sens car le Converter est vraiment spécifique au StructuredElement et ne vit que pour sa classe "soeur". Et cela évite un trop fort couplage avec JAXB.
- L'avantage, c'est que cela simplifie grandement le code de l'Adapter. En plus, on a plus besoin de gérer le cas `IllegalArgumentException` dans le cas ou on ne reconnait pas le type de l'instance, puisque ce cas ne peut plus arriver.
- La méthode `qualifiedName` est déplacée dans la classe `ExtensionElementConverter` qui devient une classe abstraite. Cela simplifie le code et en plus ca a du sens car cette méthode prend un objet atom-jaxb en entrée et un objet jaxb en sortie. C'est typiquement le role de ce Converter que de faire le lien entre les 2 mondes.
- Suppression de l'interface `ElementQNameFactory` et de la méthode `canConvert`


Au final cela donne +48 lignes - 145 lignes !