### PR TITLE
Display a "Maven central" badge in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,10 +2,9 @@
 
 Atom JAXB is Java library focused on Atom 1.0 feed marshalling/unmarshalling.
 
-## Build status
-
 [![Build Status](https://travis-ci.org/vidal-community/atom-jaxb.png)](https://travis-ci.org/vidal-community/atom-jaxb)
 [![Coverage Status](https://coveralls.io/repos/vidal-community/atom-jaxb/badge.svg?branch=master)](https://coveralls.io/r/vidal-community/atom-jaxb?branch=master)
+[![Maven Central](https://img.shields.io/maven-central/v/fr.vidal.oss/atom-jaxb.svg)](https://search.maven.org/artifact/fr.vidal.oss/atom-jaxb/)
 
 ## What it does
 


### PR DESCRIPTION
Maven central badge is a discrete way to:
* document how to use `atom-jaxb` (install via Maven/Gradle/Sbt etc.)
* show latest version

["Diff" screenshot](https://github.com/vidal-community/atom-jaxb/pull/57/files?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5):
![image](https://user-images.githubusercontent.com/3862051/99357232-ddc31380-28ab-11eb-837a-adbb51098c7b.png)
