### PR TITLE
Fix 'Report code coverage' in CI

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,5 +8,5 @@ indent_size = 4
 charset = utf-8
 trim_trailing_whitespace = true
 
-[.travis.yml]
+[*.yml]
 indent_size = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Report code coverage
         if: ${{ github.ref == 'refs/heads/master' && success() }}
         env:
-            COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
+          COVERALLS_TOKEN: ${{ secrets.COVERALLS_TOKEN }}
         run: ./mvnw test jacoco:report coveralls:report -DrepoToken=$COVERALLS_TOKEN
       - name: Publish
         if: ${{ github.ref == 'refs/heads/master' && success() }}


### PR DESCRIPTION
GitHub Action secret used for 'coveralls:report' was probably missing due to YAML indentation issue. :sob: 

We also fixed the EditorConfig configuration that had been forgotten in commit 36f367caedac3e05022384d92f8f894f8dcae723. 😇